### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: Rust
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["rsx", "jsx", "html", "macro", "rstml"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hyperide-macro = "0.0.3"
+hyperide-macro = { version = "0.0.4", path = "./macro" }
 vercel_runtime = "1.0.2"
 url = "2.4.0"
 http = "0.2.9"


### PR DESCRIPTION
This adds a basic CI setup and uses a path dependency for the local macro to make the tests pass. Currently, `cargo test` does not pass on master.